### PR TITLE
Sort, and HTML digest.

### DIFF
--- a/bin/fail2ban_digest
+++ b/bin/fail2ban_digest
@@ -48,60 +48,62 @@ Fail2ban Digest
 default_html_template = Template('''<!DOCTYPE html>
 <html>
 <head>
-    <style>
-				body {
-					font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
-				}
+  <style>
+    body {
+      font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+    }
 
-        table {
-          border-collapse: collapse;
-        }
+    table {
+      border-collapse: collapse;
+    }
 
-        td, th {
-          border: 1px solid darkgrey;
-          text-align: left;
-          padding: 6px;
-        }
+    td, th {
+      border: 1px solid darkgrey;
+      text-align: left;
+      padding: 6px;
+    }
 
-				td {
-					vertical-align: top;
-				}
+    td {
+      vertical-align: top;
+    }
 
-				td:last-child {
-					width: 1px;
-					white-space: nowrap;
-				}
+    td:last-child {
+      width: 1px;
+      white-space: nowrap;
+    }
 
-        th {
-          background-color: #dddddd;
-        }
-    </style>
+    th {
+      background-color: #dddddd;
+    }
+  </style>
 </head>
 <body>
-    <p>Hi,</p>
-    <p>This is a digest email of banned IPs since <b>${creation_date}</b> and <b>${date_now}</b>:</p>
-    <table>
-        <tr>
-            <th style="text-align: center">#</th>
-            <th style="text-align: center">IPs</th>
-            <th>When</th>
-        </tr>
+  <p>Hi,</p>
+  <p>This is a digest email of banned IPs since <b>${creation_date}</b> and <b>${date_now}</b>:</p>
+  <table>
+    <tr>
+      <th style="text-align: center">#</th>
+      <th style="text-align: center">IPs</th>
+      <th>When</th>
+    </tr>
 ${digest}
-    </table>
-    <p>Regards,</p>
-    <p><a href="https://github.com/enricotagliavini/fail2ban-digest">Fail2Ban Digest</a><p>
+  </table>
+  <p>Regards,</p>
+  <p><a href="https://github.com/enricotagliavini/fail2ban-digest">Fail2Ban Digest</a><p>
 </body>
 <html>
 ''')
-html_tr_template = Template('''        <tr>
-            <td style="text-align: center">${count}</td>
-            <td style="text-align: right">${ip}</td>
-            <td>${events}</td>
-        </tr>
+html_tr_template = Template('''    <tr>
+      <td style="text-align: center">${count}</td>
+      <td style="text-align: right">${ip}</td>
+      <td>${events}</td>
+    </tr>
 ''')
-html_error_template = Template('''        <tr>
-            <td colspan="3"><em>${error_msg}</em></td>
-        </tr>''')
+html_error_template = Template('''    <tr>
+      <td colspan="3"><em>${error_msg}</em></td>
+    </tr>
+''')
+
 class Ban:
 	def __init__(self, ip, events):
 		self.ip = ip

--- a/bin/fail2ban_digest
+++ b/bin/fail2ban_digest
@@ -110,7 +110,7 @@ def db_busy_open(filename, flags, timeout):
 
 def add(db, ip):
 	db = db_busy_open(db_location + '/' + db + '.dbm', 'c', 30)
-	if db_creation_date_key not in db.keys():
+	if db_creation_date_key.encode('UTF-8') not in db.keys():
 		db[db_creation_date_key] = datetime.utcnow().strftime(db_date_format).encode('UTF-8')
 	event_date = ('%s, ' % datetime.utcnow().strftime(db_date_format)).encode('UTF-8')
 	try:

--- a/bin/fail2ban_digest
+++ b/bin/fail2ban_digest
@@ -37,7 +37,7 @@ db_location = '/var/lib/fail2ban/digest'
 db_creation_date_key = 'db_creation_date'
 db_date_format = '%Y-%m-%d %H:%M:%S'
 default_mail_template = Template('''Hi,\n
-This is a digest email of banned IPs since ${creation_date} and ${date_now}:
+This is a digest email of the ${count} banned IPs between ${creation_date} and ${date_now}:
 
 ${digest}
 
@@ -79,7 +79,7 @@ default_html_template = Template('''<!DOCTYPE html>
 </head>
 <body>
   <p>Hi,</p>
-  <p>This is a digest email of banned IPs since <b>${creation_date}</b> and <b>${date_now}</b>:</p>
+  <p>This is a digest email of the <b>${count}</b> banned IPs between <b>${creation_date}</b> and <b>${date_now}</b>:</p>
   <table>
     <tr>
       <th style="text-align: center">#</th>
@@ -219,12 +219,12 @@ def digest(db, delete, sort):
 	for ban in events_list:
 		msg_html += html_tr_template.substitute(count = len(ban.events), ip = ban.ip, events = '<br>'.join(ban.events))
 		msg += '%3d event(s) for IP %-42s: %s\n' %(len(ban.events), ban.ip, ', '.join(ban.events))
-	return (db_creation_date, msg, msg_html)
+	return (len(events_list), db_creation_date, msg, msg_html)
 
 def mail_digest(db, mail_to, mail_from, delete, html, quiet, sort):
 	msg = EmailMessage()
 	date_now = datetime.now().strftime(db_date_format)
-	creation_date, dgst, dgst_html = digest(db, delete, sort)
+	count, creation_date, dgst, dgst_html = digest(db, delete, sort)
 	if dgst == '':
 		if quiet:
 			return
@@ -232,12 +232,14 @@ def mail_digest(db, mail_to, mail_from, delete, html, quiet, sort):
 			dgst = '    No ban event recorded for the named time frame.'
 			dgst_html = html_error_template.substitute(error_msg = dgst)
 	msg.set_content(default_mail_template.substitute(
+		count = count,
 		creation_date = creation_date,
 		date_now = date_now,
 		digest = dgst
 	))
 	if html:
 		msg.add_alternative(default_html_template.substitute(
+			count = count,
 			creation_date = creation_date,
 			date_now = date_now,
 			digest = dgst_html
@@ -254,7 +256,7 @@ def main(args):
 	if args.cmd == 'add':
 		add(args.database, args.ip)
 	elif args.cmd == 'digest':
-		print(digest(args.database, args.delete, args.sort)[1])
+		print(digest(args.database, args.delete, args.sort)[2])
 	elif args.cmd == 'maildigest':
 		mail_digest(args.database, args.to, args.mail_from, args.delete, args.html, args.quiet, args.sort)
 	elif args.cmd is None:

--- a/bin/fail2ban_digest
+++ b/bin/fail2ban_digest
@@ -34,7 +34,7 @@ import re
 import sys
 
 db_location = '/var/lib/fail2ban/digest'
-db_creation_date_key = 'db_creation_date'
+db_creation_date_key = u'db_creation_date'
 db_date_format = '%Y-%m-%d %H:%M:%S'
 default_mail_template = Template('''Hi,\n
 This is a digest email of the ${count} banned IPs between ${creation_date} and ${date_now}:
@@ -176,7 +176,7 @@ def db_busy_open(filename, flags, timeout):
 
 def add(db, ip):
 	db = db_busy_open(db_location + '/' + db + '.dbm', 'c', 30)
-	if db_creation_date_key.encode('UTF-8') not in db.keys():
+	if db_creation_date_key not in db.keys():
 		db[db_creation_date_key] = datetime.utcnow().strftime(db_date_format).encode('UTF-8')
 	event_date = ('%s, ' % datetime.utcnow().strftime(db_date_format)).encode('UTF-8')
 	try:

--- a/bin/fail2ban_digest
+++ b/bin/fail2ban_digest
@@ -45,6 +45,13 @@ Regards,
 
 Fail2ban Digest
 ''')
+class Ban:
+	def __init__(self, ip, events):
+		self.ip = ip
+		self.events = []
+		for event in events:
+			self.events.append(utc_to_local(event))
+		self.events.sort
 
 class store_yesno(argparse.Action):
 	def __init__(self, option_strings, dest, nargs = None, **kwargs):
@@ -136,23 +143,22 @@ def digest(db, delete):
 		os.rename(new_db_file, db_file)
 
 	try:
-		db_creation_date = db[db_creation_date_key].decode('UTF-8')
+		db_creation_date = utc_to_local(db[db_creation_date_key].decode('UTF-8'))
 	except KeyError as e:
 		db_creation_date = 'not found'
-	event_list = []
+	events_list = []
 	for ip in db.keys():
 		if ip.decode('UTF-8') == db_creation_date_key:
 			continue
-		event_list.append((ip.decode('UTF-8'), db[ip].decode('UTF-8').split(', ')[:-1]))
+		events_list.append(Ban(ip.decode('UTF-8'), db[ip].decode('UTF-8').split(', ')[:-1]))
 	close_db(db)
-	event_list.sort(key = lambda x: len(x[1]), reverse = True)
+	events_list.sort(key=lambda x: x.events[0]) # sort by date
+	if sort:
+		events_list.sort(key=lambda x: len(x.events), reverse=True)
 	msg = ''
-	for ip, events in event_list:
-		local_events = []
-		for event in events:
-			local_events.append(utc_to_local(event))
-		msg += '%3d event(s) for IP %-42s: %s\n' %(len(events), ip, ', '.join(local_events))
-	return (db_creation_date, msg)
+	msg_html = ''
+	for ban in events_list:
+		msg += '%3d event(s) for IP %-42s: %s\n' %(len(ban.events), ban.ip, ', '.join(ban.events))
 
 def mail_digest(db, mail_to, mail_from, delete, quiet):
 	msg = EmailMessage()
@@ -162,11 +168,11 @@ def mail_digest(db, mail_to, mail_from, delete, quiet):
 		if quiet:
 			return
 		else:
-			dgst = 'no ban event recorded for the named time frame'
+			dgst = '    No ban event recorded for the named time frame.'
 	msg.set_content(default_mail_template.substitute(
-			creation_date = utc_to_local(creation_date),
-			date_now = date_now,
-			digest = dgst,
+		creation_date = creation_date,
+		date_now = date_now,
+		digest = dgst
 	))
 	msg['To'] = mail_to
 	msg['From'] = mail_from
@@ -230,6 +236,12 @@ if __name__ == '__main__':
 			action = store_yesno,
 			default = False,
 			help = 'do / don\'t delete current database, next call to add will create a new empty one'
+	)
+	subcommands[sc].add_argument(
+		'--sort', '--no-sort',
+		action = store_yesno,
+		default = True,
+		help = 'do / don\'t sort the digest by repeat event occurrences.'
 	)
 
 	sc = 'maildigest'

--- a/bin/fail2ban_digest
+++ b/bin/fail2ban_digest
@@ -256,7 +256,7 @@ def main(args):
 	elif args.cmd == 'digest':
 		print(digest(args.database, args.delete, args.sort)[1])
 	elif args.cmd == 'maildigest':
-		mail_digest(args.database, args.to, args.mail_from, args.html, args.delete, args.quiet, args.sort)
+		mail_digest(args.database, args.to, args.mail_from, args.delete, args.html, args.quiet, args.sort)
 	elif args.cmd is None:
 		print('No action specified')
 	return

--- a/bin/fail2ban_digest
+++ b/bin/fail2ban_digest
@@ -45,6 +45,63 @@ Regards,
 
 Fail2ban Digest
 ''')
+default_html_template = Template('''<!DOCTYPE html>
+<html>
+<head>
+    <style>
+				body {
+					font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+				}
+
+        table {
+          border-collapse: collapse;
+        }
+
+        td, th {
+          border: 1px solid darkgrey;
+          text-align: left;
+          padding: 6px;
+        }
+
+				td {
+					vertical-align: top;
+				}
+
+				td:last-child {
+					width: 1px;
+					white-space: nowrap;
+				}
+
+        th {
+          background-color: #dddddd;
+        }
+    </style>
+</head>
+<body>
+    <p>Hi,</p>
+    <p>This is a digest email of banned IPs since <b>${creation_date}</b> and <b>${date_now}</b>:</p>
+    <table>
+        <tr>
+            <th style="text-align: center">#</th>
+            <th style="text-align: center">IPs</th>
+            <th>When</th>
+        </tr>
+${digest}
+    </table>
+    <p>Regards,</p>
+    <p><a href="https://github.com/enricotagliavini/fail2ban-digest">Fail2Ban Digest</a><p>
+</body>
+<html>
+''')
+html_tr_template = Template('''        <tr>
+            <td style="text-align: center">${count}</td>
+            <td style="text-align: right">${ip}</td>
+            <td>${events}</td>
+        </tr>
+''')
+html_error_template = Template('''        <tr>
+            <td colspan="3"><em>${error_msg}</em></td>
+        </tr>''')
 class Ban:
 	def __init__(self, ip, events):
 		self.ip = ip
@@ -127,7 +184,7 @@ def add(db, ip):
 	close_db(db)
 	return
 
-def digest(db, delete):
+def digest(db, delete, sort):
 	db_file = db_location + '/' + db + '.dbm'
 	new_db_file = db_location + '/.' + db + '.dbm'
 	try:
@@ -158,22 +215,31 @@ def digest(db, delete):
 	msg = ''
 	msg_html = ''
 	for ban in events_list:
+		msg_html += html_tr_template.substitute(count = len(ban.events), ip = ban.ip, events = '<br>'.join(ban.events))
 		msg += '%3d event(s) for IP %-42s: %s\n' %(len(ban.events), ban.ip, ', '.join(ban.events))
+	return (db_creation_date, msg, msg_html)
 
-def mail_digest(db, mail_to, mail_from, delete, quiet):
+def mail_digest(db, mail_to, mail_from, delete, html, quiet, sort):
 	msg = EmailMessage()
 	date_now = datetime.now().strftime(db_date_format)
-	creation_date, dgst = digest(db, delete)
+	creation_date, dgst, dgst_html = digest(db, delete, sort)
 	if dgst == '':
 		if quiet:
 			return
 		else:
 			dgst = '    No ban event recorded for the named time frame.'
+			dgst_html = html_error_template.substitute(error_msg = dgst)
 	msg.set_content(default_mail_template.substitute(
 		creation_date = creation_date,
 		date_now = date_now,
 		digest = dgst
 	))
+	if html:
+		msg.add_alternative(default_html_template.substitute(
+			creation_date = creation_date,
+			date_now = date_now,
+			digest = dgst_html
+		), subtype = 'html')
 	msg['To'] = mail_to
 	msg['From'] = mail_from
 	msg['Subject'] = '[Fail2Ban] %s: digest for %s %s' % (db, socket.gethostname(), date_now)
@@ -186,9 +252,9 @@ def main(args):
 	if args.cmd == 'add':
 		add(args.database, args.ip)
 	elif args.cmd == 'digest':
-		print(digest(args.database, args.delete)[1])
+		print(digest(args.database, args.delete, args.sort)[1])
 	elif args.cmd == 'maildigest':
-		mail_digest(args.database, args.to, args.mail_from, args.delete, args.quiet)
+		mail_digest(args.database, args.to, args.mail_from, args.html, args.delete, args.quiet, args.sort)
 	elif args.cmd is None:
 		print('No action specified')
 	return
@@ -260,6 +326,12 @@ if __name__ == '__main__':
 			help = 'do / don\'t delete current database, next call to add will create a new empty one'
 	)
 	subcommands[sc].add_argument(
+		'--html', '--no-html',
+		action = store_yesno,
+		default = False,
+		help = 'do / don\'t send the digest in HTML format.'
+	)
+	subcommands[sc].add_argument(
 			'--mail-from',
 			action = 'store',
 			default = 'Fail2ban at {0} <fail2ban@{0}>'.format(socket.gethostname()),
@@ -270,6 +342,12 @@ if __name__ == '__main__':
 			action = store_yesno,
 			default = False,
 			help = 'do / don\'t send digest if there are no ban events recorded for the named time frame'
+	)
+	subcommands[sc].add_argument(
+		'--sort', '--no-sort',
+		action = store_yesno,
+		default = True,
+		help = 'do / don\'t sort the digest by repeat event occurrences.'
 	)
 	subcommands[sc].add_argument(
 			'--to',


### PR DESCRIPTION
Quite a few changes.

First, fixed a bug where the `db_creation_date_key` was never found in the DB keys. It was not UTF-8 encoded.

Second, fixed the sorting. While there was technically nothing wrong with sorting by the number of occurrences, it created some weird behavior in most cases, for example:

```
  1 event(s) for IP 45.55.160.243                             : 2019-03-04 07:24:50
  1 event(s) for IP 159.89.116.97                             : 2019-03-04 07:06:08
  1 event(s) for IP 37.97.129.58                              : 2019-03-04 07:25:59
  1 event(s) for IP 68.183.76.110                             : 2019-03-04 06:56:15
  1 event(s) for IP 188.166.10.79                             : 2019-03-04 07:09:32
  1 event(s) for IP 66.70.188.25                              : 2019-03-04 06:38:39
  1 event(s) for IP 139.59.82.59                              : 2019-03-04 06:09:39
  1 event(s) for IP 178.62.8.222                              : 2019-03-04 07:38:59
  1 event(s) for IP 45.55.41.232                              : 2019-03-04 07:17:34
  1 event(s) for IP 104.131.93.33                             : 2019-03-04 07:20:19
  1 event(s) for IP 178.128.79.169                            : 2019-03-04 06:02:10
  1 event(s) for IP 138.68.146.186                            : 2019-03-04 07:22:52
  1 event(s) for IP 211.250.189.64                            : 2019-03-04 06:08:28
  1 event(s) for IP 14.232.202.166                            : 2019-03-04 06:03:38
```
Since all the events are 1, it basically creates a radom sort. I fixed the problem by first sorting by the event date then by occurrences. I've also added a `--sort` argument to turn sorting by occurences on or off.

Last, I've added an HTML template for the digest, which can be turned on using the `--html` argument. It is off by default. I just find the plain text template is hard to read in Gmail, etc.

![Screenshot_20190310-172601](https://user-images.githubusercontent.com/705618/54093947-41b4db00-435a-11e9-917a-e99ae8d25ca6.jpg)

I think it could be turned on by default since both the plain text and HTML template are used in the email digest, but I did not want to change the current behavior.

@enricotagliavini Let me know if you have any questions/comments/suggestions.